### PR TITLE
Integrate Liquibase and simplify entity relationships

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,10 @@
             <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
             <version>2.8.8</version>
         </dependency>
+        <dependency>
+            <groupId>org.liquibase</groupId>
+            <artifactId>liquibase-core</artifactId>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/src/main/java/com/example/dms/model/Bucket.java
+++ b/src/main/java/com/example/dms/model/Bucket.java
@@ -1,6 +1,5 @@
 package com.example.dms.model;
 
-import com.fasterxml.jackson.annotation.JsonManagedReference;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.GenericField;
@@ -13,7 +12,6 @@ import java.util.*;
 @AllArgsConstructor
 @Builder
 @EqualsAndHashCode(onlyExplicitlyIncluded = true)
-@ToString(exclude = {"parent", "subcategories", "documents"})
 public class Bucket {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -26,10 +24,6 @@ public class Bucket {
     @MapKeyColumn(name = "meta_key")
     @Column(name = "meta_value")
     private Map<String, String> metadata = new HashMap<>();
-
-    @OneToMany(mappedBy = "bucket", cascade = CascadeType.ALL, orphanRemoval = true)
-    @JsonManagedReference
-    private List<Document> documents = new ArrayList<>();
 
     // getters & setters
 }

--- a/src/main/java/com/example/dms/model/Category.java
+++ b/src/main/java/com/example/dms/model/Category.java
@@ -13,7 +13,7 @@ import org.hibernate.search.mapper.pojo.mapping.definition.annotation.*;
 @AllArgsConstructor
 @Builder
 @EqualsAndHashCode(onlyExplicitlyIncluded = true)
-@ToString(exclude = {"documents"})
+@ToString(exclude = {"parent", "subcategories"})
 public class Category {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -28,7 +28,4 @@ public class Category {
 
     @OneToMany(mappedBy = "parent", cascade = CascadeType.ALL)
     private Set<Category> subcategories = new HashSet<>();
-
-    @ManyToMany(mappedBy = "categories")
-    private Set<Document> documents = new HashSet<>();
 }

--- a/src/main/java/com/example/dms/model/Document.java
+++ b/src/main/java/com/example/dms/model/Document.java
@@ -1,6 +1,5 @@
 package com.example.dms.model;
 
-import com.fasterxml.jackson.annotation.JsonBackReference;
 import jakarta.persistence.*;
 import java.time.LocalDateTime;
 import java.util.*;
@@ -23,7 +22,6 @@ public class Document {
     @ManyToOne(optional=false)
     @JoinColumn(name="bucket_id")
     @IndexedEmbedded()
-    @JsonBackReference
     private Bucket bucket;
 
     @ManyToOne(optional=false)

--- a/src/main/java/com/example/dms/model/Tag.java
+++ b/src/main/java/com/example/dms/model/Tag.java
@@ -2,8 +2,6 @@ package com.example.dms.model;
 
 import jakarta.persistence.*;
 
-import java.util.*;
-
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -22,9 +20,6 @@ public class Tag {
 
     @FullTextField
     private String name;
-
-    @ManyToMany(mappedBy = "tags")
-    private Set<Document> documents = new HashSet<>();
 
     // getters & setters
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,5 +1,6 @@
 spring.datasource.url=jdbc:h2:mem:testdb
 spring.datasource.username=sa
 spring.datasource.password=
-spring.jpa.hibernate.ddl-auto=create-drop
+spring.jpa.hibernate.ddl-auto=none
+spring.liquibase.change-log=classpath:db/changelog/db.changelog-master.yaml
 spring.h2.console.enabled=true

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -1,0 +1,185 @@
+databaseChangeLog:
+  - changeSet:
+      id: 1
+      author: auto
+      changes:
+        - createTable:
+            tableName: binary_content
+            columns:
+              - column:
+                  name: content_hash
+                  type: varchar(255)
+                  constraints:
+                    primaryKey: true
+              - column:
+                  name: filename
+                  type: varchar(255)
+              - column:
+                  name: content_type
+                  type: varchar(255)
+              - column:
+                  name: data
+                  type: blob
+        - createTable:
+            tableName: bucket
+            columns:
+              - column:
+                  name: id
+                  type: bigint
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+              - column:
+                  name: name
+                  type: varchar(255)
+        - createTable:
+            tableName: bucket_metadata
+            columns:
+              - column:
+                  name: bucket_id
+                  type: bigint
+                  constraints:
+                    nullable: false
+              - column:
+                  name: meta_key
+                  type: varchar(255)
+              - column:
+                  name: meta_value
+                  type: varchar(255)
+        - addForeignKeyConstraint:
+            baseTableName: bucket_metadata
+            baseColumnNames: bucket_id
+            referencedTableName: bucket
+            referencedColumnNames: id
+        - createTable:
+            tableName: category
+            columns:
+              - column:
+                  name: id
+                  type: bigint
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+              - column:
+                  name: name
+                  type: varchar(255)
+              - column:
+                  name: parent_id
+                  type: bigint
+        - addForeignKeyConstraint:
+            baseTableName: category
+            baseColumnNames: parent_id
+            referencedTableName: category
+            referencedColumnNames: id
+        - createTable:
+            tableName: tag
+            columns:
+              - column:
+                  name: id
+                  type: bigint
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+              - column:
+                  name: name
+                  type: varchar(255)
+        - createTable:
+            tableName: document
+            columns:
+              - column:
+                  name: id
+                  type: bigint
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+              - column:
+                  name: bucket_id
+                  type: bigint
+                  constraints:
+                    nullable: false
+              - column:
+                  name: content_hash
+                  type: varchar(255)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: uploaded_at
+                  type: timestamp
+              - column:
+                  name: text_content
+                  type: clob
+        - addForeignKeyConstraint:
+            baseTableName: document
+            baseColumnNames: bucket_id
+            referencedTableName: bucket
+            referencedColumnNames: id
+        - addForeignKeyConstraint:
+            baseTableName: document
+            baseColumnNames: content_hash
+            referencedTableName: binary_content
+            referencedColumnNames: content_hash
+        - createTable:
+            tableName: document_metadata
+            columns:
+              - column:
+                  name: document_id
+                  type: bigint
+                  constraints:
+                    nullable: false
+              - column:
+                  name: meta_key
+                  type: varchar(255)
+              - column:
+                  name: meta_value
+                  type: varchar(255)
+        - addForeignKeyConstraint:
+            baseTableName: document_metadata
+            baseColumnNames: document_id
+            referencedTableName: document
+            referencedColumnNames: id
+        - createTable:
+            tableName: document_category
+            columns:
+              - column:
+                  name: document_id
+                  type: bigint
+                  constraints:
+                    nullable: false
+              - column:
+                  name: category_id
+                  type: bigint
+                  constraints:
+                    nullable: false
+        - addForeignKeyConstraint:
+            baseTableName: document_category
+            baseColumnNames: document_id
+            referencedTableName: document
+            referencedColumnNames: id
+        - addForeignKeyConstraint:
+            baseTableName: document_category
+            baseColumnNames: category_id
+            referencedTableName: category
+            referencedColumnNames: id
+        - createTable:
+            tableName: document_tag
+            columns:
+              - column:
+                  name: document_id
+                  type: bigint
+                  constraints:
+                    nullable: false
+              - column:
+                  name: tag_id
+                  type: bigint
+                  constraints:
+                    nullable: false
+        - addForeignKeyConstraint:
+            baseTableName: document_tag
+            baseColumnNames: document_id
+            referencedTableName: document
+            referencedColumnNames: id
+        - addForeignKeyConstraint:
+            baseTableName: document_tag
+            baseColumnNames: tag_id
+            referencedTableName: tag
+            referencedColumnNames: id


### PR DESCRIPTION
## Summary
- Adopt Liquibase for database migrations and configure Spring Boot to use it.
- Remove bidirectional relationships from entities to avoid inter-entity loops.
- Add initial changelog covering core tables and join tables.

## Testing
- `mvn -q test` *(fails: Network is unreachable to Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_68a4c680f7c483218cba58297218765b